### PR TITLE
Lock firefox version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:30
 
 LABEL maintainer="PnT DevOps Automation - Red Hat, Inc." \
       vendor="PnT DevOps Automation - Red Hat, Inc." \
@@ -13,7 +13,7 @@ ENV CHROME_BIN=chromium-browser NODE_EXTRA_CA_CERTS=/opt/ca.crt
 RUN dnf install -y --setopt=tsflags=nodocs \
     chromium \
     chromium-headless \
-    firefox \
+    firefox-66.0.2-1.fc30 \
     ipa-gothic-fonts \
     libXt \
     npm \


### PR DESCRIPTION
Locking firefox version as 68+ stalls on CI.

https://github.com/karma-runner/karma-firefox-launcher/issues/104